### PR TITLE
Fix production entry script for Cloudflare deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,22 +10,9 @@
         overscroll-behavior: none;
       }
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react/": "https://aistudiocdn.com/react@^19.1.1/",
-    "react": "https://aistudiocdn.com/react@^19.1.1",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/"
-  }
-}
-</script>
-    <script src="https://cdn.jsdelivr.net/npm/@mediapipe/selfie_segmentation@0.1.1675465747/selfie_segmentation.js" crossorigin="anonymous"></script>
-    <!-- Add Babel for in-browser JSX/TSX transpilation -->
-    <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
-</head>
+  </head>
   <body class="bg-gray-900 text-white antialiased">
     <div id="root"></div>
-    <!-- Change script type to text/babel to be processed by Babel -->
-    <script type="text/babel" data-presets="react,typescript" src="/index.tsx"></script>
+    <script type="module" src="/index.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: './',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- remove the in-browser Babel setup from `index.html`
- rely on Vite's module entry so Pages serves the transpiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d135980778832891a060796d3c275a